### PR TITLE
トップメッセージページのモーダル閉じるボタンの位置調整

### DIFF
--- a/src/styles/sections/message/_video.scss
+++ b/src/styles/sections/message/_video.scss
@@ -76,13 +76,9 @@
       z-index: 11;
       width: 40px;
       height: 40px;
-      top: 12%;
-      right: 10%;
+      top: 3rem;
+      right: 3rem;
       cursor: pointer;
-      @include sp {
-        top: 3rem;
-        right: 3rem;
-      }
     }
     .modal__closeBtn::before,
     .modal__closeBtn::after {


### PR DESCRIPTION
PC版の動画モーダルの閉じるボタンの位置がずれていたので修正しました。